### PR TITLE
Update setup.sh to use HTTPS instead of SSH

### DIFF
--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-OSJS_URI=git@github.com:os-js
+OSJS_URI=https://github.com/os-js
 
 OSJS_REPOS=(
   # Misc


### PR DESCRIPTION
Fixes the issue with being unable to run lerna after cloning the repo due to setup.sh attempting to clone over SSH.

fixes #1